### PR TITLE
Update class path to use htmlunit-2.45.0

### DIFF
--- a/org/fae/util/classpath
+++ b/org/fae/util/classpath
@@ -2,7 +2,7 @@
 
 echo $FAE_HOME
 
-HP=$FAE_HOME/lib/htmlunit-2.39.0/lib/*.jar
+HP=$FAE_HOME/lib/htmlunit-2.45.0/lib/*.jar
 
 echo $HP
 


### PR DESCRIPTION
- The current version of htmlunit-2.39.0 is causing compilation errors